### PR TITLE
Wait for last child rather than post/comment element itself

### DIFF
--- a/src/extensionPreferences/index.ts
+++ b/src/extensionPreferences/index.ts
@@ -86,11 +86,15 @@ function loadFeatures() {
 }
 
 loadFeatures();
-waitForAllElements(".link:not(.ol-post-container .link), .comment", (post: HTMLDivElement) => {
+// the .clearleft is the last element in a link post. we need all the elements present for link posts so that setupPostContainer
+// can move them into the container. on the other hand, comments aren't subject to setupPostContainer, so we can process them as
+// soon as the .child element occurs. this avoids having to wait for all their replies to load.
+waitForAllElements(".link:not(.ol-post-container .link) > .clearleft, .comment > .child", (marker: HTMLElement) => {
+    const post = marker.parentElement as HTMLDivElement;
     if (post.classList.contains("riok")) {
         return
     }
-    loadedFeatures.forEach(async (feature: OLFeature) => { 
+    loadedFeatures.forEach(async (feature: OLFeature) => {
         await feature.onPost(post);
     });
     post.classList.add("riok");


### PR DESCRIPTION
Hi there, I was investigating some other issues with gallery behaviour and I found this bug which occurs occasionally during slow page loads. You can see an example here:

<img width="980" height="1804" alt="image" src="https://github.com/user-attachments/assets/63ffa138-6658-4e8a-85f2-910a4d50e87e" />

Notice how on the 7th post, the buttons don't render properly. I believe this happens because, when waiting for the post and comment elements to be loaded, the waitForAllElements handler triggers as soon as the opening tag is received rather than when the element contents are fully downloaded. On a slow connection, this might mean that not all of the child elements are loaded yet, which in rare cases can cause a broken transformation like shown above.

Instead of waiting for the element itself, the change in this PR waits for a child element which signals that we have everything we need to do the transformation successfully. For posts, it waits for the .clearleft, which is the last child element. That's because we need all the elements for posts so they can get moved into a new container by setupPostContainer. For comments, it just waits for the start of the .child element, which contains all the replies. This allows us to start processing the comment right away without having to wait for the replies to load, which is safe because comments aren't subject to setupPostContainer.

Thanks, Shawn